### PR TITLE
Refactor TimeRange provider

### DIFF
--- a/ui/app/src/components/variable/VariableDrawer.tsx
+++ b/ui/app/src/components/variable/VariableDrawer.tsx
@@ -11,17 +11,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { DispatchWithPromise, VariableDefinition, Variable, getVariableProject } from '@perses-dev/core';
-import React, { Dispatch, DispatchWithoutAction, useEffect, useMemo, useState } from 'react';
-import { DatasourceStoreProvider, TemplateVariableProvider } from '@perses-dev/dashboards';
 import { Drawer, ErrorAlert, ErrorBoundary } from '@perses-dev/components';
+import { DispatchWithPromise, Variable, VariableDefinition, getVariableProject } from '@perses-dev/core';
+import { DatasourceStoreProvider, TemplateVariableProvider } from '@perses-dev/dashboards';
 import {
   Action,
   PluginRegistry,
-  TimeRangeProvider,
-  useInitialTimeRange,
+  TimeRangeFromQueryProvider,
   VariableEditorForm,
+  useInitialTimeRange,
 } from '@perses-dev/plugin-system';
+import { Dispatch, DispatchWithoutAction, useEffect, useMemo, useState } from 'react';
 import { bundledPluginLoader } from '../../model/bundled-plugins';
 import { CachedDatasourceAPI, HTTPDatasourceAPI } from '../../model/datasource-api';
 import { DeleteVariableDialog } from '../dialogs/DeleteVariableDialog';
@@ -81,7 +81,7 @@ export function VariableDrawer<T extends Variable>(props: VariableDrawerProps<T>
           }}
         >
           <DatasourceStoreProvider datasourceApi={datasourceApi} projectName={projectName}>
-            <TimeRangeProvider initialTimeRange={initialTimeRange} enabledURLParams={true}>
+            <TimeRangeFromQueryProvider initialTimeRange={initialTimeRange}>
               <TemplateVariableProvider initialVariableDefinitions={[]}>
                 <VariableEditorForm
                   initialVariableDefinition={variableDef}
@@ -93,7 +93,7 @@ export function VariableDrawer<T extends Variable>(props: VariableDrawerProps<T>
                   onDelete={onDelete ? () => setDeleteVariableDialogStateOpened(true) : undefined}
                 />
               </TemplateVariableProvider>
-            </TimeRangeProvider>
+            </TimeRangeFromQueryProvider>
           </DatasourceStoreProvider>
         </PluginRegistry>
         {onDelete && (

--- a/ui/dashboards/src/components/Panel/Panel.test.tsx
+++ b/ui/dashboards/src/components/Panel/Panel.test.tsx
@@ -43,7 +43,7 @@ describe('Panel', () => {
     definition ??= createTestPanel();
 
     renderWithContext(
-      <TimeRangeProvider initialTimeRange={{ pastDuration: '1h' }}>
+      <TimeRangeProvider timeRange={{ pastDuration: '1h' }}>
         <TemplateVariableProvider
           initialVariableDefinitions={[
             {

--- a/ui/dashboards/src/components/PanelGroupDialog/PanelGroupDialog.test.tsx
+++ b/ui/dashboards/src/components/PanelGroupDialog/PanelGroupDialog.test.tsx
@@ -24,7 +24,7 @@ describe('Add Panel Group', () => {
 
     renderWithContext(
       <DashboardProvider initialState={{ dashboardResource: getTestDashboard(), isEditMode: true }}>
-        <TimeRangeProvider initialTimeRange={{ pastDuration: '1h' }}>
+        <TimeRangeProvider timeRange={{ pastDuration: '1h' }}>
           <TemplateVariableProvider>
             <DashboardProviderSpy />
             <PanelGroupDialog />

--- a/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.test.tsx
+++ b/ui/dashboards/src/components/TimeRangeControls/TimeRangeControls.test.tsx
@@ -15,7 +15,7 @@ import { generatePath } from 'react-router';
 import { createMemoryHistory } from 'history';
 import userEvent from '@testing-library/user-event';
 import { screen, act } from '@testing-library/react';
-import { TimeRangeProvider } from '@perses-dev/plugin-system';
+import { TimeRangeProvider, TimeRangeFromQuery } from '@perses-dev/plugin-system';
 import { renderWithContext } from '../../test';
 import testDashboard from '../../test/testDashboard';
 import { DashboardProvider, DashboardStoreProps, TemplateVariableProvider } from '../../context';
@@ -39,15 +39,22 @@ describe('TimeRangeControls', () => {
   const renderTimeRangeControls = (testURLParams: boolean) => {
     renderWithContext(
       <DashboardProvider initialState={initialState}>
-        <TimeRangeProvider
-          initialRefreshInterval={testDefaultRefreshInterval}
-          initialTimeRange={testDefaultTimeRange}
-          enabledURLParams={testURLParams}
-        >
-          <TemplateVariableProvider>
-            <TimeRangeControls />
-          </TemplateVariableProvider>
-        </TimeRangeProvider>
+        {testURLParams ? (
+          <TimeRangeFromQuery
+            initialRefreshInterval={testDefaultRefreshInterval}
+            initialTimeRange={testDefaultTimeRange}
+          >
+            <TemplateVariableProvider>
+              <TimeRangeControls />
+            </TemplateVariableProvider>
+          </TimeRangeFromQuery>
+        ) : (
+          <TimeRangeProvider refreshInterval={testDefaultRefreshInterval} timeRange={testDefaultTimeRange}>
+            <TemplateVariableProvider>
+              <TimeRangeControls />
+            </TemplateVariableProvider>
+          </TimeRangeProvider>
+        )}
       </DashboardProvider>,
       undefined,
       history

--- a/ui/dashboards/src/views/ViewDashboard/ViewDashboard.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/ViewDashboard.tsx
@@ -15,7 +15,7 @@ import { Box, BoxProps } from '@mui/material';
 import { BuiltinVariableDefinition, DEFAULT_DASHBOARD_DURATION, DEFAULT_REFRESH_INTERVAL } from '@perses-dev/core';
 import { ErrorBoundary, ErrorAlert, combineSx } from '@perses-dev/components';
 import {
-  TimeRangeProvider,
+  TimeRangeFromQuery,
   useInitialRefreshInterval,
   useInitialTimeRange,
   usePluginBuiltinVariableDefinitions,
@@ -101,11 +101,7 @@ export function ViewDashboard(props: ViewDashboardProps) {
   return (
     <DatasourceStoreProvider dashboardResource={dashboardResource} datasourceApi={datasourceApi}>
       <DashboardProvider initialState={{ dashboardResource, isEditMode: !!isEditing }}>
-        <TimeRangeProvider
-          initialTimeRange={initialTimeRange}
-          initialRefreshInterval={initialRefreshInterval}
-          enabledURLParams={true}
-        >
+        <TimeRangeFromQuery initialTimeRange={initialTimeRange} initialRefreshInterval={initialRefreshInterval}>
           <TemplateVariableProvider
             initialVariableDefinitions={spec.variables}
             externalVariableDefinitions={externalVariableDefinitions}
@@ -138,7 +134,7 @@ export function ViewDashboard(props: ViewDashboardProps) {
               </ErrorBoundary>
             </Box>
           </TemplateVariableProvider>
-        </TimeRangeProvider>
+        </TimeRangeFromQuery>
       </DashboardProvider>
     </DatasourceStoreProvider>
   );

--- a/ui/dashboards/src/views/ViewDashboard/tests/panelGroups.test.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/tests/panelGroups.test.tsx
@@ -22,7 +22,7 @@ describe('Panel Groups', () => {
   const renderDashboard = () => {
     renderWithContext(
       <DatasourceStoreProvider {...defaultDatasourceProps}>
-        <TimeRangeProvider initialRefreshInterval="0s" initialTimeRange={{ pastDuration: '30m' }}>
+        <TimeRangeProvider refreshInterval="0s" timeRange={{ pastDuration: '30m' }}>
           <TemplateVariableProvider>
             <DashboardProvider initialState={{ dashboardResource: getTestDashboard(), isEditMode: true }}>
               <DashboardApp dashboardResource={getTestDashboard()} isReadonly={false} />

--- a/ui/plugin-system/src/runtime/TimeRangeProvider/TimeRangeFromQueryProvider.tsx
+++ b/ui/plugin-system/src/runtime/TimeRangeProvider/TimeRangeFromQueryProvider.tsx
@@ -1,0 +1,41 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { DurationString, TimeRangeValue } from '@perses-dev/core';
+import React from 'react';
+import { TimeRangeProvider } from './TimeRangeProvider';
+import { useSetRefreshIntervalParams, useTimeRangeParams } from './query-params';
+
+export interface TimeRangeFromQueryProps {
+  initialTimeRange: TimeRangeValue;
+  initialRefreshInterval?: DurationString;
+  children?: React.ReactNode;
+}
+
+export function TimeRangeFromQueryProvider(props: TimeRangeFromQueryProps) {
+  const { initialTimeRange, initialRefreshInterval, children } = props;
+
+  const { timeRange, setTimeRange } = useTimeRangeParams(initialTimeRange);
+  const { refreshInterval, setRefreshInterval } = useSetRefreshIntervalParams(initialRefreshInterval);
+
+  return (
+    <TimeRangeProvider
+      timeRange={timeRange}
+      refreshInterval={refreshInterval}
+      setTimeRange={setTimeRange}
+      setRefreshInterval={setRefreshInterval}
+    >
+      {children}
+    </TimeRangeProvider>
+  );
+}

--- a/ui/plugin-system/src/runtime/TimeRangeProvider/index.ts
+++ b/ui/plugin-system/src/runtime/TimeRangeProvider/index.ts
@@ -12,4 +12,5 @@
 // limitations under the License.
 
 export * from './TimeRangeProvider';
+export * from './TimeRangeFromQueryProvider';
 export * from './query-params';

--- a/ui/plugin-system/src/runtime/TimeRangeProvider/refresh-interval.ts
+++ b/ui/plugin-system/src/runtime/TimeRangeProvider/refresh-interval.ts
@@ -1,0 +1,16 @@
+import { DurationString, parseDurationString } from '@perses-dev/core';
+
+/**
+ * Utils function to transform a refresh interval in {@link DurationString} format into a number of ms.
+ * @param refreshInterval
+ */
+export function getRefreshIntervalInMs(refreshInterval?: DurationString) {
+  let refreshIntervalInMs = 0;
+  if (refreshInterval) {
+    const refreshIntervalDuration = parseDurationString(refreshInterval);
+    if (refreshIntervalDuration && refreshIntervalDuration.seconds) {
+      refreshIntervalInMs = refreshIntervalDuration?.seconds * 1000;
+    }
+  }
+  return refreshIntervalInMs;
+}

--- a/ui/plugin-system/src/stories/shared-utils/decorators/WithTimeRange.tsx
+++ b/ui/plugin-system/src/stories/shared-utils/decorators/WithTimeRange.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { StoryFn, StoryContext } from '@storybook/react';
-import { TimeRangeProvider, TimeRangeProviderProps } from '@perses-dev/plugin-system';
+import { TimeRangeProvider, TimeRangeFromQueryProps } from '@perses-dev/plugin-system';
 
 declare module '@storybook/react' {
   interface Parameters {
@@ -21,7 +21,7 @@ declare module '@storybook/react' {
 }
 
 export type WithTimeRangeParameter = {
-  props: Partial<TimeRangeProviderProps>;
+  props: Partial<TimeRangeFromQueryProps>;
 };
 
 // Type guard because storybook types parameters as `any`
@@ -35,7 +35,7 @@ export const WithTimeRange = (Story: StoryFn, context: StoryContext<unknown>) =>
   const props = parameter?.props;
 
   return (
-    <TimeRangeProvider initialRefreshInterval="0s" initialTimeRange={{ pastDuration: '1h' }} {...props}>
+    <TimeRangeProvider refreshInterval="0s" timeRange={{ pastDuration: '1h' }} {...props}>
       <Story />
     </TimeRangeProvider>
   );


### PR DESCRIPTION
# Description

Decouple the TimeRange provider from the QueryProvider, fallback to local state and create a TimeRangeWithQueryProvider to ease use when time range from query is needed

# Screenshots

No UI changes